### PR TITLE
Make xml-doclet java 1.6 compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<downloadSources>true</downloadSources>
 		<downloadJavadocs>true</downloadJavadocs>
-		<java.version>1.7</java.version>
+		<java.version>1.6</java.version>
 	</properties>
 
 	<scm>

--- a/src/main/java/com/github/markusbernhardt/xmldoclet/XmlDoclet.java
+++ b/src/main/java/com/github/markusbernhardt/xmldoclet/XmlDoclet.java
@@ -224,7 +224,7 @@ public class XmlDoclet {
 	 */
 	public static CommandLine parseCommandLine(String[][] optionsArrayArray) {
 		try {
-			List<String> argumentList = new ArrayList<>();
+			List<String> argumentList = new ArrayList<String>();
 			for (String[] optionsArray : optionsArrayArray) {
 				argumentList.addAll(Arrays.asList(optionsArray));
 			}


### PR DESCRIPTION
Although java 1.6 is not officially supported anymore, there still are a lot of unfortunate souls who need to keep on using it for various reasons. (I am one of them.) I need selenium2library's java port to run on 1.6 and that in turn needs xml-doclet.

The change needed to make xml-doclet java 1.6 compliant is only one line. It would be very helpful for us, if you could include this change in a future release of selenium2library for java.

Thanks!
